### PR TITLE
Update dependencies and configurations for JDK 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The code is explained in a series of blog posts.
 
 ## Project Requirements
 
-* JDK 22
-* Spring Boot 3.3
+* JDK 23
+* Spring Boot 3.4
 
 ## The Business Problem
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 name: spring-modulith-with-ddd
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:24.0.3
+    image: quay.io/keycloak/keycloak:latest
     command: ['start-dev', '--import-realm']
     volumes:
       - ./keycloak-realm:/opt/keycloak/data/import

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-modulith-with-ddd</name>
 	<description>Spring Modulith with DDD</description>
 	<properties>
-		<java.version>22</java.version>
+		<java.version>23</java.version>
 		<maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
 		<springdoc-openapi-starter-webmvc-ui.version>2.8.1</springdoc-openapi-starter-webmvc-ui.version>
 		<spring-modulith-bom.version>1.3.1</spring-modulith-bom.version>
@@ -160,7 +160,7 @@
 							<BPL_JAVA_NMT_ENABLED>false</BPL_JAVA_NMT_ENABLED>
 							<BP_SPRING_CLOUD_BINDINGS_DISABLED>true</BP_SPRING_CLOUD_BINDINGS_DISABLED>
 							<BP_JVM_CDS_ENABLED>true</BP_JVM_CDS_ENABLED>
-							<BP_JVM_VERSION>22</BP_JVM_VERSION>
+							<BP_JVM_VERSION>23</BP_JVM_VERSION>
 						</env>
 					</image>
 					<excludes>


### PR DESCRIPTION
Updated the project to use JDK 23 and Spring Boot 3.4 by modifying `README.md`, `pom.xml`, and configuration files. Additionally, switched the Keycloak image in `docker-compose.yml` to use the latest version for improved compatibility. These changes ensure the project remains up-to-date with the latest tools and dependencies.